### PR TITLE
xpath for the homepage

### DIFF
--- a/crawler.rb
+++ b/crawler.rb
@@ -9,7 +9,7 @@ base = 'https://mediabiasfactcheck.com'
 
 biases = {}
 
-if ARGV[0.nil?
+if ARGV[0].nil?
   directory = 'output'
   unless File.directory?('output')
     Dir.mkdir('output')
@@ -135,4 +135,3 @@ if (sources.count > 0)
 else
   puts "No sources to write."
 end
-

--- a/dry.rb
+++ b/dry.rb
@@ -65,7 +65,7 @@ module DRY
           result
         end
 
-        homepage({ xpath: '//div[contains(@class, "entry-content")]//p[text()[starts-with(.,"Sourc")]]/a/@href'})
+        homepage({ xpath: '//div[contains(@class, "entry-content") or contains(@class, "entry")]//p[text()[starts-with(.,"Source:") or starts-with(.,"Sources:")]]/a/@href'})
 
         domain({ xpath: '//div[contains(@class, "entry")]//p[text()[starts-with(.,"Sourc")]]/a/@href'}) do |d|
           # remove www, www2, etc.


### PR DESCRIPTION
Conspiracy sources have wrong homepage (xpath selector takes the first p that begins with “Sourc”, but there is also another p with “Sources …”: example at https://mediabiasfactcheck.com/nutritionfacts-org/

The result is that they have `"homepage": "https://mediabiasfactcheck.com/conspiracy/"` that is wrong.

Possible options:

Selecting with “Source:”

- works for conspiracy sources
- Some pages have “Sources:” https://mediabiasfactcheck.com/msnbc/

Selecting with “target=“blank”:
- works for conspiracy sources
- Some pages don’t have the target: https://mediabiasfactcheck.com/die-hard-democrat/\

Solution:
- Select those that match “^Sources?:”: “Source:” or “Sources:”

Another problem: some have the homepage in the entry without the entry-content: https://mediabiasfactcheck.com/alt-news/

- Added the or option

Still one null homepage: https://mediabiasfactcheck.com/nutritionfacts-org/
- The xpath is `//*[@id="page-28486"]/div[3]/div[2]/p[10]/em/a` (there is an em causing problems, but also failed before the modification)

The attachment [files.zip](https://github.com/JeffreyATW/mbfc_crawler/files/3358840/files.zip)
contains the following:
- `sources_old.json` the results of scraping before the fix (formatted for comparison)
- `sources.json` the results of scraping after the fix (formatted for comparison)
- `diff.txt` the difference between the two files, showing that there are no drawbacks

