### PR TITLE
fix satire and right-center biases

### DIFF
--- a/crawler.rb
+++ b/crawler.rb
@@ -61,11 +61,8 @@ end
         d.sub(/see also:/i, '').strip
       end
       url "#{base}/#{p}/"
-      if p == 'satire' || p == 'right-center'
-        source_urls 'xpath=//*/div[@id="table-container"]/table//tr/td/a/@href', :list
-      else
-        source_urls 'xpath=//*/div[contains(@class, "entry")]/p/a/@href', :list
-      end
+      # for some kind of bias, they are in a table-container
+      source_urls({ xpath: '//*/div[contains(@class, "entry")]/p/a/@href | //*/div[@id="table-container"]/table//tr/td/a/@href' }, :list)
     end
 
     puts "Bias crawled: #{bias['name']}"

--- a/crawler.rb
+++ b/crawler.rb
@@ -61,7 +61,11 @@ end
         d.sub(/see also:/i, '').strip
       end
       url "#{base}/#{p}/"
-      source_urls 'xpath=//*/div[contains(@class, "entry")]/p[position()=3]/a/@href', :list
+      if p == 'satire' || p == 'right-center'
+        source_urls 'xpath=//*/div[@id="table-container"]/table//tr/td/a/@href', :list
+      else
+        source_urls 'xpath=//*/div[contains(@class, "entry")]/p/a/@href', :list
+      end
     end
 
     puts "Bias crawled: #{bias['name']}"


### PR DESCRIPTION
Some categories have changed the structure of the page listing the sources:

https://mediabiasfactcheck.com/right-center/
https://mediabiasfactcheck.com/satire/

They are using a table now.

Without this fix, the `right-center` and `satire` categories will be empty.